### PR TITLE
Don't exit on duplicates

### DIFF
--- a/src/main/java/edu/illinois/cs/cogcomp/wikiparser/jwpl/jwplparsers/PageMapLineParser.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/wikiparser/jwpl/jwplparsers/PageMapLineParser.java
@@ -217,7 +217,6 @@ public class PageMapLineParser {
                     curidsToTitles.put(id, pageTitle);
                 } else {
                     System.out.println("curidsToTitles already contains duplicate curid: " + id);
-                    System.exit(0);
                 }
             }
             fileReader.close();


### PR DESCRIPTION
duplicates are skipped rather than forcing a System.exit